### PR TITLE
Added vendored deps to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-lib
-vendor
-log
 data
-tmp
 dist
+lib
+log
 out
+pkg
+tmp
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 data
 dist
 lib

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -1,5 +1,4 @@
 ###########################################################
-
 # build script
 ###########################################################
 
@@ -27,13 +26,13 @@ GOLANG_VERSION=1.10
 GOLANG_SRC=tmp/golang
 
 GLFW_URL=github.com/go-gl/glfw/v3.2/glfw
-GLFW=vendor/src/$(GLFW_URL)
+GLFW_PATH=vendor/src/$(GLFW_URL)
 GOGL_URL=github.com/go-gl/gl/v4.1-core/gl
-GOGL=vendor/src/$(GOGL_URL)
+GOGL_PATH=vendor/src/$(GOGL_URL)
 
 GOLANG_PATH=lib/go-$(GOLANG_VERSION)
 GOLANG_BIN=$(GOLANG_PATH)/bin
-GOLANG_BINARY=$(GOLANG_BIN)/go
+GOLANG_BINARY=$(CURDIR)/$(GOLANG_BIN)/go
 GOLANG_TEST_BINARY=./script/gotest-color
 
 # TEST_FILES_EXPR=./src/...
@@ -51,12 +50,6 @@ test: $(GOLANG_BINARY) $(GOLANG_TEST_BINARY)
 	@echo "-------------------------------------------------------------------------------"
 	$(GOLANG_TEST_BINARY) test -v ./src/...
 
-# Get the requested packages and install into our vendor path
-# Call like: 
-#    make get ARGS="-u -v github.com/go-gl/glfw/v3.2/glfw"
-get: $(GOLANG_BINARY)
-	cd vendor && $(GOLANG_BINARY) get ${ARGS}
-
 # Run the application binary
 run: $(GOLANG_BINARY)
 	$(GOLANG_BINARY) run ./src/github.com/lukebayes/findingyou/findingyou.go
@@ -71,7 +64,7 @@ clean:
 	rm -rf out
 
 # Intall development dependencies (OS X and Linux only)
-dev-install: $(GOLANG_BINARY) $(SKIA_LIB) $(GLFW) $(GOGL)
+dev-install: $(GOLANG_BINARY) $(SKIA_LIB) $(GLFW_PATH) $(GOGL_PATH)
 
 # Download and unpack the Golang binaries into lib/.
 $(GOLANG_BINARY):
@@ -106,9 +99,9 @@ $(SKIA_LIB): $(SKIA_SRC)
 vendor:
 	mkdir -p vendor
 
-$(GLFW): vendor
-	cd vendor/; ../$(GOLANG_BINARY) get -v $(GLFW_URL)
+$(GLFW_PATH): vendor
+	cd vendor/; $(GOLANG_BINARY) get -u -v $(GLFW_URL)
 
-$(GOGL): vendor
-	cd vendor/; ../$(GOLANG_BINARY) get -v $(GOGL_URL)
+$(GOGL_PATH): vendor
+	cd vendor/; $(GOLANG_BINARY) get -u -v $(GOGL_URL)
 

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -26,6 +26,11 @@ GOARCH=$(ARCH)
 GOLANG_VERSION=1.10
 GOLANG_SRC=tmp/golang
 
+GLFW_URL=github.com/go-gl/glfw/v3.2/glfw
+GLFW=vendor/src/$(GLFW_URL)
+GOGL_URL=github.com/go-gl/gl/v4.1-core/gl
+GOGL=vendor/src/$(GOGL_URL)
+
 GOLANG_PATH=lib/go-$(GOLANG_VERSION)
 GOLANG_BIN=$(GOLANG_PATH)/bin
 GOLANG_BINARY=$(GOLANG_BIN)/go
@@ -66,7 +71,7 @@ clean:
 	rm -rf out
 
 # Intall development dependencies (OS X and Linux only)
-dev-install: $(GOLANG_BINARY) $(SKIA_LIB)
+dev-install: $(GOLANG_BINARY) $(SKIA_LIB) $(GLFW) $(GOGL)
 
 # Download and unpack the Golang binaries into lib/.
 $(GOLANG_BINARY):
@@ -96,4 +101,14 @@ $(SKIA_SRC): $(DEPOT_TOOLS)
 $(SKIA_LIB): $(SKIA_SRC)
 	cd $(SKIA_SRC); gn gen out/Shared --args='is_official_build=false is_component_build=true'
 	cd $(SKIA_SRC); ninja -C out/Shared
+
+# Create the vendor directory
+vendor:
+	mkdir -p vendor
+
+$(GLFW): vendor
+	cd vendor/; ../$(GOLANG_BINARY) get -v $(GLFW_URL)
+
+$(GOGL): vendor
+	cd vendor/; ../$(GOLANG_BINARY) get -v $(GOGL_URL)
 

--- a/golang/setup-env.sh
+++ b/golang/setup-env.sh
@@ -46,7 +46,7 @@ export GOPATH="${BASEDIR}:${BASEDIR}/vendor"
 echo "Set GOPATH to $GOPATH"
 
 # Set CGO_LDFLAGS so that CGO can access Skia libraries
-export CGO_LDFLAGS="-L ${BASEDIR}/lib/skia/out/Shared -Wl -rpath ${BASEDIR}/lib/skia/out/Shared -lskia"
+export CGO_LDFLAGS="-L ${BASEDIR}/lib/skia/out/Shared -lskia"
 echo "Set CGO_LDFLAGS=${CGO_LDFLAGS}"
 
 # Set CGO_CFLAGS so that CGO can access Skia libraries

--- a/golang/setup-env.sh
+++ b/golang/setup-env.sh
@@ -38,11 +38,13 @@ add_to_path "${BASEDIR}/lib/depot_tools"
 echo "Updated PATH with ${BASEDIR}/lib/depot_tools"
 
 # Set the custom GOROOT value to the local Go installation.
-export GOROOT="${BASEDIR}/lib/go-1.10"
-echo "Set GOROOT to ${BASEDIR}/lib/go-1.10"
+# export GOROOT="${BASEDIR}/lib/go-1.10"
+# echo "Set GOROOT to ${BASEDIR}/lib/go-1.10"
 
 # Set the gopath for this project
-export GOPATH="${BASEDIR}:${BASEDIR}/vendor"
+# NOTE: It's critical that vendor is the first entry here so that go get calls
+# place external source files into vendor/src and NOT into src/...
+export GOPATH="${BASEDIR}/vendor:${BASEDIR}"
 echo "Set GOPATH to $GOPATH"
 
 # Set CGO_LDFLAGS so that CGO can access Skia libraries
@@ -52,4 +54,8 @@ echo "Set CGO_LDFLAGS=${CGO_LDFLAGS}"
 # Set CGO_CFLAGS so that CGO can access Skia libraries
 export CGO_CFLAGS="-I${BASEDIR}/lib/skia/include/c"
 echo "Set CGO_CFLAGS=${CGO_CFLAGS}"
+
+# Set GOBIN so that commands are installed appropriately
+export GOBIN=${BASEDIR}/bin
+echo "Set GOBIN=${GOBIN}"
 

--- a/golang/src/gnomplate.go
+++ b/golang/src/gnomplate.go
@@ -1,0 +1,16 @@
+package main
+
+/**
+* Sample code found here:
+* https://medium.com/@drgomesp/opengl-and-golang-getting-started-abcd3d96f3db
+ */
+
+import (
+	"github.com/lukebayes/gnomplate"
+)
+
+func main() {
+	opts := &gnomplate.WindowOptions{Title: "Gnomplate"}
+	window := gnomplate.CreateWindow(opts)
+	window.Open()
+}


### PR DESCRIPTION
Tried to use `dep` as per latest and greatest recommendation, but this approach would force me to segregate what is currently 3 projects or place my project root at github.com/lukebayes and in either case, it shits out the vendor directory inside of my src/ folder. :hankey: :nauseated_face: 

The current approach places ./vendor as the first entry in GOPATH and this seems to be where `go get` decides to drop it's turds.